### PR TITLE
Put single part sections in a part

### DIFF
--- a/pbcorethat
+++ b/pbcorethat
@@ -28,22 +28,6 @@ _maketemp(){
     fi
 }
 
-# This finds all the csvs into the folder to be analyzed and strings them together and makes an xml representation of that.
-_make_inventory(){
-    # find inventories
-    INVENTORY_LIST=$(_maketemp)
-    find "${ANALYSIS_DIR}" -maxdepth 1 -mindepth 1 -name "*.csv" ! -name ".*" > "${INVENTORY_LIST}"
-
-    if [[ $(cat "${INVENTORY_LIST}" | awk 'END{print NR}') = "0" ]] ; then
-        # if no inventories are found, complain and exit
-        echo "Error: no inventory files were found in $(basename "${INVENTORY_LIST}")"
-        exit
-    else
-        INVENTORY_CAT=$(_maketemp)
-        cat "${ANALYSIS_DIR}"/*.csv | csvprintf -x -f - > "${INVENTORY_CAT}"
-    fi
-}
-
 # if not arguments, then show the help stuff and exit
 if [ "${#}" = 0 ] ; then
     _usage

--- a/pbcorethat
+++ b/pbcorethat
@@ -167,15 +167,22 @@ find "${ANALYSIS_DIR}" -maxdepth 1 -mindepth 1 -name "*_*" -type d | while read 
             _get_mediainfo "$FILE"
             BASENAME=$(basename "${FILE}")
             FILE_BASE=$(echo "${BASENAME%%_[prt][0-9][0-9]_*}")
+            FILE_BASE=$(echo "${FILE_BASE%%_[ab]_*}")
             PART_LABEL=$(echo "$FILE" | grep -o "_[prt][0-9][0-9]_")
             PART_LABEL_S=$(echo "$FILE" | grep -o "_[prt][0-9][0-9]")
             PART_IDENTIFIER="${FILE_BASE}${PART_LABEL_S}"
-            PART_XML="/tmp/pbcorethat_${PART_LABEL}.xml"
+            if [[ -z "$PART_LABEL" ]] ; then
+                PART_LABEL="_p0_"
+                PART_LABEL_S="_p0_"
+                PART_IDENTIFIER="${FILE_BASE}"
+            fi
+            PART_XML="/tmp/pbcorethat_part_${PART_LABEL}.xml"
             MI_ORIGINAL_INST="/tmp/pbcorethat_${PART_LABEL}original.xml"
             MI_ORIGINAL_NONPART_INST="/tmp/pbcorethat_${PART_LABEL}original_nonpart.xml"
 
-            if [[ "$FILE" = *_[prt][0-9][0-9]_a_* ]]; then
+            if [[ "$FILE" = *_a_* ]]; then
                 _determine_instantiation_relation "$FILE" "${MI_TMP}" "${PART_IDENTIFIER%.*}"
+                _setup_original_instantiation
                 echo "$BASENAME is part of a multipart instantiation within the pbcorePart of $PART_LABEL_S"
                 INST_PART_XML=$(_maketemp)
 
@@ -208,43 +215,6 @@ find "${ANALYSIS_DIR}" -maxdepth 1 -mindepth 1 -name "*_*" -type d | while read 
                 fi
                 xsltproc --stringparam instantiationpart "$INST_PART_XML" "${SCRIPTDIR}/insertinstantiation2pbcorepart.xsl" "$PART_XML" | xmlstarlet fo > "${PART_XML}.new.xml"
                 mv "${PART_XML}.new.xml" "$PART_XML"
-
-            elif [[ "$FILE" = *_a_* ]]; then
-                _determine_instantiation_relation "$FILE" "${MI_TMP}" "$OBJECT_ID"
-                _setup_original_instantiation
-                echo "$BASENAME is part of a multi sided instantiation"
-                INST_PART_XML=$(_maketemp)
-
-                B_FILE=$(echo "$FILE" | sed "s/_a_/_b_/g")
-                INST_PART_LIST="${MI_TMP}"
-                INST_PART_LIST+="+"
-                if [[ -f "$B_FILE" ]] ; then
-                    _get_mediainfo "$B_FILE"
-                     _determine_instantiation_relation "$FILE" "${MI_TMP}" "$OBJECT_ID"
-                    INST_PART_LIST+="$MI_TMP"
-                    INST_PART_LIST+="+"
-                fi
-
-                echo "<pbcoreInstantiationDocument xmlns=\"http://www.pbcore.org/PBCore/PBCoreNamespace.html\"/>" > "$INST_PART_XML"
-                xmlstarlet edit --inplace -N "p=http://www.pbcore.org/PBCore/PBCoreNamespace.html" \
-                    --subnode "/p:pbcoreInstantiationDocument" --type elem -n "instantiationIdentifier" -v "$(echo "${BASENAME%.*}" | sed "s/_a_/_/g")" "$INST_PART_XML"
-                xmlstarlet edit --inplace -N "p=http://www.pbcore.org/PBCore/PBCoreNamespace.html" \
-                    --insert "/p:pbcoreInstantiationDocument/p:instantiationIdentifier" -t attr -n "source" -v "California Revealed" "$INST_PART_XML"
-                xmlstarlet edit --inplace -N "p=http://www.pbcore.org/PBCore/PBCoreNamespace.html" \
-                    --insert "/p:pbcoreInstantiationDocument/p:instantiationIdentifier" -t attr -n "annotation" -v "Object Identifier" "$INST_PART_XML"
-                xmlstarlet edit --inplace -N "p=http://www.pbcore.org/PBCore/PBCoreNamespace.html" \
-                    --subnode "/p:pbcoreInstantiationDocument" --type elem -n "instantiationLocation" -v "California Revealed Digital Repository" "$INST_PART_XML"
-                xsltproc --stringparam instantiationpart "${INST_PART_LIST%?}" "${SCRIPTDIR}/insertinstantiationpart2instantiation.xsl" "$INST_PART_XML" | xmlstarlet fo > "${INST_PART_XML}.new.xml"
-                mv "${INST_PART_XML}.new.xml" "$INST_PART_XML"
-
-                if [[ "$FILE" = *"prsv"* ]]; then
-                    MI_LIST_PRSV+="${INST_PART_XML}"
-                    MI_LIST_PRSV+="+"
-                else
-                    MI_LIST_ACCESS+="${INST_PART_XML}"
-                    MI_LIST_ACCESS+="+"
-                fi
-
 
             elif [[ "$FILE" = *_[prt][0-9][0-9]_* ]]; then
                 _determine_instantiation_relation "$FILE" "${MI_TMP}" "$PART_IDENTIFIER"

--- a/pbcorethat
+++ b/pbcorethat
@@ -216,18 +216,8 @@ find "${ANALYSIS_DIR}" -maxdepth 1 -mindepth 1 -name "*_*" -type d | while read 
                 xsltproc --stringparam instantiationpart "$INST_PART_XML" "${SCRIPTDIR}/insertinstantiation2pbcorepart.xsl" "$PART_XML" | xmlstarlet fo > "${PART_XML}.new.xml"
                 mv "${PART_XML}.new.xml" "$PART_XML"
 
-            elif [[ "$FILE" = *_[prt][0-9][0-9]_* ]]; then
-                _determine_instantiation_relation "$FILE" "${MI_TMP}" "$PART_IDENTIFIER"
-                echo "$BASENAME is an instantiation within the pbcorePart of $PART_LABEL_S"
-                if [[ ! -f "$PART_XML" ]] ; then
-                    _setup_original_instantiation_as_part
-                    MI_PARTS+="$PART_XML"
-                    MI_PARTS+="+"
-                fi
-                xsltproc --stringparam instantiationpart "${MI_TMP}" "${SCRIPTDIR}/insertinstantiation2pbcorepart.xsl" "$PART_XML" | xmlstarlet fo > "${PART_XML}.new.xml"
-                mv "${PART_XML}.new.xml" "$PART_XML"
             else
-                _determine_instantiation_relation "$FILE" "${MI_TMP}" "$OBJECT_ID"
+                _determine_instantiation_relation "$FILE" "${MI_TMP}" "$PART_IDENTIFIER"
                 echo "$BASENAME is an instantiation within the pbcorePart of $PART_LABEL_S"
                 if [[ ! -f "$PART_XML" ]] ; then
                     _setup_original_instantiation_as_part


### PR DESCRIPTION
should resolve https://github.com/cavpp/cavppers/issues/18. There used to be many construction scenario based on the need for various combinations of pbcorePart, instantiation, and instantiationPart. Now there's only two scenarios, such as does the instantiation need to be expressed with instantiationParts or not, since with this update all non-original-object instantiations shall be within a PBCorePart even if there's no part-code use indicating only one part.

I left the original object record (audio cassette, etc) outside of the pbcorePart though. Is that the right place or would you prefer it within the pbcorePart. Currently it's like

```xml
<asset>
   <instantiation>audio tape</instantiation>
   <pbcorepart>
      <instantiation>digital files</instantiation>
   </pbcorepart>
</asset>
```